### PR TITLE
Fixing email sending broken when attempting to send emails from different goroutines due to a data race

### DIFF
--- a/base_interface.go
+++ b/base_interface.go
@@ -56,24 +56,20 @@ func requestNew(options options) rest.Request {
 	}
 }
 
-// Send sends an email through Twilio SendGrid without additional
+// Send sends an email through Twilio SendGrid
 func (cl *Client) Send(email *mail.SGMailV3) (*rest.Response, error) {
 	return cl.SendWithContext(context.Background(), email, nil)
 }
 
-// SendWithHeaders sends an email through Twilio SendGrid with additional headers.
-func (cl *Client) SendWIthHeaders(email *mail.SGMailV3, headers map[string]string) (*rest.Response, error) {
+// SendWithHeaders sends an email through Twilio SendGrid with additional headers
+func (cl *Client) SendWithHeaders(email *mail.SGMailV3, headers map[string]string) (*rest.Response, error) {
 	return cl.SendWithContext(context.Background(), email, headers)
 }
 
-// SendWithContext sends an email through Twilio SendGrid with context.Context.
+// SendWithContext sends an email through Twilio SendGrid with context.Context
 func (cl *Client) SendWithContext(ctx context.Context, email *mail.SGMailV3, headers map[string]string) (*rest.Response, error) {
 	var request rest.Request
 
-	// Determine the authentication method:
-	// 1. If an API key is available, use it to create a request.
-	// 2. If Twilio email options are provided, use them instead.
-	// 3. If neither is available, return an error.
 	if cl.apiKey != "" {
 		request = GetRequest(cl.apiKey, "/v3/mail/send", "")
 	} else if cl.emailOptions != (TwilioEmailOptions{}) {
@@ -82,15 +78,13 @@ func (cl *Client) SendWithContext(ctx context.Context, email *mail.SGMailV3, hea
 		return nil, errors.New("no API key or email options provided")
 	}
 
-	// Set the HTTP method to POST, as required by SendGrid's API.
 	request.Method = "POST"
 
-	// Add any custom headers provided by the caller.
+	// Add any custom headers provided by the caller
 	for k, v := range headers {
 		request.Headers[k] = v
 	}
 
-	// Convert the email object into JSON format to be sent in the request body.
 	request.Body = mail.GetRequestBody(email)
 	// when Content-Encoding header is set to "gzip"
 	// mail body is compressed using gzip according to

--- a/base_interface.go
+++ b/base_interface.go
@@ -29,7 +29,8 @@ type options struct {
 
 // Client is the Twilio SendGrid Go client
 type Client struct {
-	rest.Request
+	apiKey       string
+	emailOptions TwilioEmailOptions
 }
 
 func (o *options) baseURL() string {
@@ -55,21 +56,49 @@ func requestNew(options options) rest.Request {
 	}
 }
 
-// Send sends an email through Twilio SendGrid
+// Send sends an email through Twilio SendGrid without additional
 func (cl *Client) Send(email *mail.SGMailV3) (*rest.Response, error) {
-	return cl.SendWithContext(context.Background(), email)
+	return cl.SendWithContext(context.Background(), email, nil)
+}
+
+// SendWithHeaders sends an email through Twilio SendGrid with additional headers.
+func (cl *Client) SendWIthHeaders(email *mail.SGMailV3, headers map[string]string) (*rest.Response, error) {
+	return cl.SendWithContext(context.Background(), email, headers)
 }
 
 // SendWithContext sends an email through Twilio SendGrid with context.Context.
-func (cl *Client) SendWithContext(ctx context.Context, email *mail.SGMailV3) (*rest.Response, error) {
-	cl.Body = mail.GetRequestBody(email)
+func (cl *Client) SendWithContext(ctx context.Context, email *mail.SGMailV3, headers map[string]string) (*rest.Response, error) {
+	var request rest.Request
+
+	// Determine the authentication method:
+	// 1. If an API key is available, use it to create a request.
+	// 2. If Twilio email options are provided, use them instead.
+	// 3. If neither is available, return an error.
+	if cl.apiKey != "" {
+		request = GetRequest(cl.apiKey, "/v3/mail/send", "")
+	} else if cl.emailOptions != (TwilioEmailOptions{}) {
+		request = GetTwilioEmailRequest(cl.emailOptions)
+	} else {
+		return nil, errors.New("no API key or email options provided")
+	}
+
+	// Set the HTTP method to POST, as required by SendGrid's API.
+	request.Method = "POST"
+
+	// Add any custom headers provided by the caller.
+	for k, v := range headers {
+		request.Headers[k] = v
+	}
+
+	// Convert the email object into JSON format to be sent in the request body.
+	request.Body = mail.GetRequestBody(email)
 	// when Content-Encoding header is set to "gzip"
 	// mail body is compressed using gzip according to
 	// https://docs.sendgrid.com/api-reference/mail-send/mail-send#mail-body-compression
-	if cl.Headers["Content-Encoding"] == "gzip" {
+	if request.Headers["Content-Encoding"] == "gzip" {
 		var gzipped bytes.Buffer
 		gz := gzip.NewWriter(&gzipped)
-		if _, err := gz.Write(cl.Body); err != nil {
+		if _, err := gz.Write(request.Body); err != nil {
 			return nil, err
 		}
 		if err := gz.Flush(); err != nil {
@@ -79,9 +108,9 @@ func (cl *Client) SendWithContext(ctx context.Context, email *mail.SGMailV3) (*r
 			return nil, err
 		}
 
-		cl.Body = gzipped.Bytes()
+		request.Body = gzipped.Bytes()
 	}
-	return MakeRequestWithContext(ctx, cl.Request)
+	return MakeRequestWithContext(ctx, request)
 }
 
 // DefaultClient is used if no custom HTTP client is defined

--- a/sendgrid.go
+++ b/sendgrid.go
@@ -2,8 +2,9 @@ package sendgrid
 
 import (
 	"errors"
-	"github.com/sendgrid/rest"
 	"net/url"
+
+	"github.com/sendgrid/rest"
 )
 
 // sendGridOptions for CreateRequest
@@ -51,9 +52,7 @@ func createSendGridRequest(sgOptions sendGridOptions) rest.Request {
 
 // NewSendClient constructs a new Twilio SendGrid client given an API key
 func NewSendClient(key string) *Client {
-	request := GetRequest(key, "/v3/mail/send", "")
-	request.Method = "POST"
-	return &Client{request}
+	return &Client{apiKey: key}
 }
 
 // extractEndpoint extracts the endpoint from a baseURL

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1640,10 +1641,89 @@ func Test_test_mail_batch__batch_id__get(t *testing.T) {
 	assert.Equal(t, 200, response.StatusCode, "Wrong status code returned")
 }
 
+func Test_test_client_send_unique_concurrent_requests(t *testing.T) {
+	// API key for authentication (use environment variables in production)
+	apiKey := "SENDGIRD_APIKEY"
+
+	// Number of concurrent requests to send
+	const numRequests = 10
+
+	// WaitGroup to synchronize goroutines
+	var wg sync.WaitGroup
+
+	// Buffered channel to collect errors from goroutines
+	errors := make(chan error, numRequests)
+
+	// Initialize the email client
+	client := NewSendClient(apiKey)
+
+	// Launch multiple goroutines to send concurrent requests
+	for i := 0; i < numRequests; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			// Create sender email details
+			from := &mail.Email{
+				Name:    fmt.Sprintf("#%d Sender", i),
+				Address: "joe.doe@example.com",
+			}
+
+			// Create recipient email details
+			to := &mail.Email{
+				Name:    fmt.Sprintf("Recipient #%d", i),
+				Address: "jane.doe@example.com",
+			}
+
+			// Construct the email message
+			email := &mail.SGMailV3{
+				From: from,
+				Personalizations: []*mail.Personalization{
+					{
+						To:      []*mail.Email{to},
+						Subject: fmt.Sprintf("#%d Hello from thread!", i),
+					},
+				},
+				Content: []*mail.Content{
+					{
+						Type:  "text/plain",
+						Value: fmt.Sprintf("This is a unique message from thread #%d.", i),
+					},
+				},
+			}
+
+			// Send the email request
+			response, err := client.Send(email)
+
+			// Handle potential errors in sending
+			if err != nil {
+				errors <- fmt.Errorf("goroutine %d: send error: %v", i, err)
+				return
+			}
+
+			// Verify the response status code
+			if response.StatusCode != 202 {
+				errors <- fmt.Errorf("goroutine %d: unexpected status code: got %d, want 202, Response: %s",
+					i, response.StatusCode, response.Body)
+				return
+			}
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
+	close(errors)
+
+	// Process any errors collected from goroutines
+	for err := range errors {
+		if err != nil {
+			t.Errorf("Test failed: %v", err)
+		}
+	}
+}
 func Test_test_send_client_with_mail_body_compression_enabled(t *testing.T) {
 	apiKey := "SENDGRID_API_KEY"
 	client := NewSendClient(apiKey)
-	client.Headers["Content-Encoding"] = "gzip"
 
 	emailBytes := []byte(` {
 		"asm": {
@@ -1780,8 +1860,10 @@ func Test_test_send_client_with_mail_body_compression_enabled(t *testing.T) {
 	email := &mail.SGMailV3{}
 	err := json.Unmarshal(emailBytes, email)
 	assert.Nil(t, err, fmt.Sprintf("Unmarshal error: %v", err))
-	client.Request.Headers["X-Mock"] = "202"
-	response, err := client.Send(email)
+
+	headers := map[string]string{"Content-Encoding": "gzip", "X-Mock": "202"}
+
+	response, err := client.SendWIthHeaders(email, headers)
 	if err != nil {
 		t.Log(err)
 	}
@@ -1929,8 +2011,7 @@ func Test_test_send_client(t *testing.T) {
 	email := &mail.SGMailV3{}
 	err := json.Unmarshal(emailBytes, email)
 	assert.Nil(t, err, fmt.Sprintf("Unmarshal error: %v", err))
-	client.Request.Headers["X-Mock"] = "202"
-	response, err := client.Send(email)
+	response, err := client.SendWIthHeaders(email, map[string]string{"X-Mock": "202"})
 	if err != nil {
 		t.Log(err)
 	}

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -1658,7 +1658,7 @@ func Test_test_client_send_is_thread_safe(t *testing.T) {
 			}
 
 			to := &mail.Email{
-				Name:    fmt.Sprintf("Recipient #%d", i),
+				Name:    "Recipient",
 				Address: "jane.doe@example.com",
 			}
 

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -1641,20 +1641,10 @@ func Test_test_mail_batch__batch_id__get(t *testing.T) {
 	assert.Equal(t, 200, response.StatusCode, "Wrong status code returned")
 }
 
-func Test_test_client_send_unique_concurrent_requests(t *testing.T) {
-	// API key for authentication (use environment variables in production)
+func Test_test_client_send_is_thread_safe(t *testing.T) {
 	apiKey := "SENDGIRD_APIKEY"
-
-	// Number of concurrent requests to send
-	const numRequests = 10
-
-	// WaitGroup to synchronize goroutines
+	const numRequests = 5
 	var wg sync.WaitGroup
-
-	// Buffered channel to collect errors from goroutines
-	errors := make(chan error, numRequests)
-
-	// Initialize the email client
 	client := NewSendClient(apiKey)
 
 	// Launch multiple goroutines to send concurrent requests
@@ -1662,65 +1652,38 @@ func Test_test_client_send_unique_concurrent_requests(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-
-			// Create sender email details
 			from := &mail.Email{
-				Name:    fmt.Sprintf("#%d Sender", i),
-				Address: "joe.doe@example.com",
+				Name:    "Name",
+				Address: "sam.smith@example.com",
 			}
 
-			// Create recipient email details
 			to := &mail.Email{
 				Name:    fmt.Sprintf("Recipient #%d", i),
 				Address: "jane.doe@example.com",
 			}
 
-			// Construct the email message
 			email := &mail.SGMailV3{
 				From: from,
 				Personalizations: []*mail.Personalization{
 					{
 						To:      []*mail.Email{to},
-						Subject: fmt.Sprintf("#%d Hello from thread!", i),
+						Subject: "Subject",
 					},
 				},
 				Content: []*mail.Content{
 					{
 						Type:  "text/plain",
-						Value: fmt.Sprintf("This is a unique message from thread #%d.", i),
+						Value: "Value",
 					},
 				},
 			}
 
-			// Send the email request
-			response, err := client.Send(email)
-
-			// Handle potential errors in sending
-			if err != nil {
-				errors <- fmt.Errorf("goroutine %d: send error: %v", i, err)
-				return
-			}
-
-			// Verify the response status code
-			if response.StatusCode != 202 {
-				errors <- fmt.Errorf("goroutine %d: unexpected status code: got %d, want 202, Response: %s",
-					i, response.StatusCode, response.Body)
-				return
-			}
+			client.Send(email)
 		}(i)
 	}
-
-	// Wait for all goroutines to complete
 	wg.Wait()
-	close(errors)
-
-	// Process any errors collected from goroutines
-	for err := range errors {
-		if err != nil {
-			t.Errorf("Test failed: %v", err)
-		}
-	}
 }
+
 func Test_test_send_client_with_mail_body_compression_enabled(t *testing.T) {
 	apiKey := "SENDGRID_API_KEY"
 	client := NewSendClient(apiKey)
@@ -1863,7 +1826,7 @@ func Test_test_send_client_with_mail_body_compression_enabled(t *testing.T) {
 
 	headers := map[string]string{"Content-Encoding": "gzip", "X-Mock": "202"}
 
-	response, err := client.SendWIthHeaders(email, headers)
+	response, err := client.SendWithHeaders(email, headers)
 	if err != nil {
 		t.Log(err)
 	}
@@ -2011,7 +1974,7 @@ func Test_test_send_client(t *testing.T) {
 	email := &mail.SGMailV3{}
 	err := json.Unmarshal(emailBytes, email)
 	assert.Nil(t, err, fmt.Sprintf("Unmarshal error: %v", err))
-	response, err := client.SendWIthHeaders(email, map[string]string{"X-Mock": "202"})
+	response, err := client.SendWithHeaders(email, map[string]string{"X-Mock": "202"})
 	if err != nil {
 		t.Log(err)
 	}

--- a/twilio_email.go
+++ b/twilio_email.go
@@ -16,9 +16,8 @@ type TwilioEmailOptions struct {
 
 // NewTwilioEmailSendClient constructs a new Twilio Email client given a username and password
 func NewTwilioEmailSendClient(username, password string) *Client {
-	request := GetTwilioEmailRequest(TwilioEmailOptions{Username: username, Password: password, Endpoint: "/v3/mail/send"})
-	request.Method = "POST"
-	return &Client{request}
+	emailOptions := &TwilioEmailOptions{Username: username, Password: password, Endpoint: "/v3/mail/send"}
+	return &Client{emailOptions: *emailOptions}
 }
 
 // GetTwilioEmailRequest create Request

--- a/twilio_email_test.go
+++ b/twilio_email_test.go
@@ -13,8 +13,9 @@ import (
 
 func TestNewTwilioEmailSendClient(t *testing.T) {
 	mailClient := NewTwilioEmailSendClient("username", "password")
-	assert.Equal(t, "https://email.twilio.com/v3/mail/send", mailClient.BaseURL)
-	assert.Equal(t, "Basic dXNlcm5hbWU6cGFzc3dvcmQ=", mailClient.Headers["Authorization"])
+	request := GetTwilioEmailRequest(mailClient.emailOptions)
+	assert.Equal(t, "https://email.twilio.com/v3/mail/send", request.BaseURL)
+	assert.Equal(t, "Basic dXNlcm5hbWU6cGFzc3dvcmQ=", request.Headers["Authorization"])
 }
 
 func TestGetTwilioEmailRequest(t *testing.T) {


### PR DESCRIPTION
# Fixes #

When trying to send several emails at the same time, the emails are not sent because the client uses a shared built-in field `rest.Request`, which is overwritten by different goroutines.
```go
// Client is the Twilio SendGrid Go client
type Client struct {
	rest.Request
}
```
```go
// SendWithContext sends an email through Twilio SendGrid with context.Context
func (cl *Client) SendWithContext(ctx context.Context, email *mail.SGMailV3) (*rest.Response, error) {
	cl.Request.Body = mail.GetRequestBody(email)

	// ...
}
```

Here is a test I wrote to show this:
```go
func Test_test_client_send_is_thread_safe(t *testing.T) {
	apiKey := "SENDGIRD_APIKEY"
	const numRequests = 5
	var wg sync.WaitGroup
	client := NewSendClient(apiKey)

	// Launch multiple goroutines to send concurrent requests
	for i := 0; i < numRequests; i++ {
		wg.Add(1)
		go func(i int) {
			defer wg.Done()
			from := &mail.Email{
				Name:    "Name",
				Address: "sam.smith@example.com",
			}

			to := &mail.Email{
				Name:    "Recipient",
				Address: "jane.doe@example.com",
			}

			email := &mail.SGMailV3{
				From: from,
				Personalizations: []*mail.Personalization{
					{
						To:      []*mail.Email{to},
						Subject: "Subject",
					},
				},
				Content: []*mail.Content{
					{
						Type:  "text/plain",
						Value: "Value",
					},
				},
			}

			client.Send(email)
		}(i)
	}
	wg.Wait()
}
```
```bash
go test ./... -v -run=Test_test_client_send_is_thread_safe -race
```
Here is the console output after running the test before applying my fixes:
```text
testing.go:1399: race detected during execution of test
--- FAIL: Test_test_client_send_is_thread_safe (0.83s)
```

After my fixes, the test passes, emails are successfully sent, and the client is now thread-safe.

I replaced the embedded Request in Client with two private fields: apiKey and emailOptions. When creating a client, either apiKey or Username and Password are required.

**New Implementation:**

```go
// Client is the Twilio SendGrid Go client
type Client struct {
	apiKey       string
	emailOptions TwilioEmailOptions
}
```

I also created the SendWithHeaders method to support additional headers (used in testing). Additionally, I refactored the client creation methods (NewSendClient and NewTwilioEmailSendClient) accordingly.

**New ApiKeySendClient:**
```go
// NewSendClient constructs a new Twilio SendGrid client given an API key
func NewSendClient(key string) *Client {
	return &Client{apiKey: key}
}
```

**New EmailSendClient:**
```go
// NewTwilioEmailSendClient constructs a new Twilio Email client given a username and password
func NewTwilioEmailSendClient(username, password string) *Client {
	emailOptions := &TwilioEmailOptions{Username: username, Password: password, Endpoint: "/v3/mail/send"}
	return &Client{emailOptions: *emailOptions}
}
```

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
