### PR TITLE
Fixing email sending broken when attempting to send emails from different goroutines due to a data race

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2024, Twilio SendGrid, Inc. <help@twilio.com>
+Copyright (C) 2025, Twilio SendGrid, Inc. <help@twilio.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/go.coverage.sh
+++ b/go.coverage.sh
@@ -4,7 +4,7 @@ set -e
 echo > coverage.txt
 
 for d in $(go list ./... | grep -v -E '/vendor|/examples|/docker'); do
-    go test -coverprofile=profile.out -covermode=atomic "$d"
+    go test -race -coverprofile=profile.out -covermode=atomic "$d"
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt
         rm profile.out

--- a/sendgrid.go
+++ b/sendgrid.go
@@ -2,8 +2,9 @@ package sendgrid
 
 import (
 	"errors"
-	"github.com/sendgrid/rest"
 	"net/url"
+
+	"github.com/sendgrid/rest"
 )
 
 // sendGridOptions for CreateRequest
@@ -51,9 +52,7 @@ func createSendGridRequest(sgOptions sendGridOptions) rest.Request {
 
 // NewSendClient constructs a new Twilio SendGrid client given an API key
 func NewSendClient(key string) *Client {
-	request := GetRequest(key, "/v3/mail/send", "")
-	request.Method = "POST"
-	return &Client{request}
+	return &Client{apiKey: key}
 }
 
 // extractEndpoint extracts the endpoint from a baseURL

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -1687,7 +1687,6 @@ func Test_test_client_send_is_thread_safe(t *testing.T) {
 func Test_test_send_client_with_mail_body_compression_enabled(t *testing.T) {
 	apiKey := "SENDGRID_API_KEY"
 	client := NewSendClient(apiKey)
-	client.Headers["Content-Encoding"] = "gzip"
 
 	emailBytes := []byte(` {
 		"asm": {
@@ -1824,8 +1823,10 @@ func Test_test_send_client_with_mail_body_compression_enabled(t *testing.T) {
 	email := &mail.SGMailV3{}
 	err := json.Unmarshal(emailBytes, email)
 	assert.Nil(t, err, fmt.Sprintf("Unmarshal error: %v", err))
-	client.Request.Headers["X-Mock"] = "202"
-	response, err := client.Send(email)
+
+	headers := map[string]string{"Content-Encoding": "gzip", "X-Mock": "202"}
+
+	response, err := client.SendWithHeaders(email, headers)
 	if err != nil {
 		t.Log(err)
 	}
@@ -1973,8 +1974,7 @@ func Test_test_send_client(t *testing.T) {
 	email := &mail.SGMailV3{}
 	err := json.Unmarshal(emailBytes, email)
 	assert.Nil(t, err, fmt.Sprintf("Unmarshal error: %v", err))
-	client.Request.Headers["X-Mock"] = "202"
-	response, err := client.Send(email)
+	response, err := client.SendWithHeaders(email, map[string]string{"X-Mock": "202"})
 	if err != nil {
 		t.Log(err)
 	}

--- a/twilio_email.go
+++ b/twilio_email.go
@@ -16,9 +16,8 @@ type TwilioEmailOptions struct {
 
 // NewTwilioEmailSendClient constructs a new Twilio Email client given a username and password
 func NewTwilioEmailSendClient(username, password string) *Client {
-	request := GetTwilioEmailRequest(TwilioEmailOptions{Username: username, Password: password, Endpoint: "/v3/mail/send"})
-	request.Method = "POST"
-	return &Client{request}
+	emailOptions := &TwilioEmailOptions{Username: username, Password: password, Endpoint: "/v3/mail/send"}
+	return &Client{emailOptions: *emailOptions}
 }
 
 // GetTwilioEmailRequest create Request

--- a/twilio_email_test.go
+++ b/twilio_email_test.go
@@ -13,8 +13,9 @@ import (
 
 func TestNewTwilioEmailSendClient(t *testing.T) {
 	mailClient := NewTwilioEmailSendClient("username", "password")
-	assert.Equal(t, "https://email.twilio.com/v3/mail/send", mailClient.BaseURL)
-	assert.Equal(t, "Basic dXNlcm5hbWU6cGFzc3dvcmQ=", mailClient.Headers["Authorization"])
+	request := GetTwilioEmailRequest(mailClient.emailOptions)
+	assert.Equal(t, "https://email.twilio.com/v3/mail/send", request.BaseURL)
+	assert.Equal(t, "Basic dXNlcm5hbWU6cGFzc3dvcmQ=", request.Headers["Authorization"])
 }
 
 func TestGetTwilioEmailRequest(t *testing.T) {


### PR DESCRIPTION
# Fixes #

When trying to send several emails at the same time, the emails are not sent because the client uses a shared built-in field `rest.Request`, which is overwritten by different goroutines.
```go
// Client is the Twilio SendGrid Go client
type Client struct {
	rest.Request
}
```
```go
// SendWithContext sends an email through Twilio SendGrid with context.Context
func (cl *Client) SendWithContext(ctx context.Context, email *mail.SGMailV3) (*rest.Response, error) {
	cl.Request.Body = mail.GetRequestBody(email)

	// ...
}
```

Here is a test I wrote to show this:
```go
func Test_test_client_send_is_thread_safe(t *testing.T) {
	apiKey := "SENDGIRD_APIKEY"
	const numRequests = 5
	var wg sync.WaitGroup
	client := NewSendClient(apiKey)

	// Launch multiple goroutines to send concurrent requests
	for i := 0; i < numRequests; i++ {
		wg.Add(1)
		go func(i int) {
			defer wg.Done()
			from := &mail.Email{
				Name:    "Name",
				Address: "sam.smith@example.com",
			}

			to := &mail.Email{
				Name:    "Recipient",
				Address: "jane.doe@example.com",
			}

			email := &mail.SGMailV3{
				From: from,
				Personalizations: []*mail.Personalization{
					{
						To:      []*mail.Email{to},
						Subject: "Subject",
					},
				},
				Content: []*mail.Content{
					{
						Type:  "text/plain",
						Value: "Value",
					},
				},
			}

			client.Send(email)
		}(i)
	}
	wg.Wait()
}
```

**Started the test using the following command:**
```bash
go test ./... -v -run=Test_test_client_send_is_thread_safe -race
```
Here is the console output after running the test before applying my fixes:
```text
testing.go:1399: race detected during execution of test
--- FAIL: Test_test_client_send_is_thread_safe (0.83s)
```

After my fixes, the test passes, emails are successfully sent, and the client is now thread-safe.

I replaced the embedded Request in Client with two private fields: apiKey and emailOptions. When creating a client, either apiKey or Username and Password are required.

**New Implementation:**

```go
// Client is the Twilio SendGrid Go client
type Client struct {
	apiKey       string
	emailOptions TwilioEmailOptions
}
```

I also created the SendWithHeaders method to support additional headers (used in testing). Additionally, I refactored the client creation methods (NewSendClient and NewTwilioEmailSendClient) accordingly.

**NewApiKeySendClient:**
```go
// NewSendClient constructs a new Twilio SendGrid client given an API key
func NewSendClient(key string) *Client {
	return &Client{apiKey: key}
}
```

**NewEmailSendClient:**
```go
// NewTwilioEmailSendClient constructs a new Twilio Email client given a username and password
func NewTwilioEmailSendClient(username, password string) *Client {
	emailOptions := &TwilioEmailOptions{Username: username, Password: password, Endpoint: "/v3/mail/send"}
	return &Client{emailOptions: *emailOptions}
}
```

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
